### PR TITLE
feat: added edhoc_export_prk_exporter_with_context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+Version 1.16.0
+--------------
+
+:Date: July 10, 2026
+
+* `@emiltin <https://github.com/emiltin>`__ : API:
+
+  * Added ``edhoc_export_prk_exporter_with_context`` to support the complete
+    RFC 9528 ``EDHOC_Exporter(label, context, length)`` input while preserving
+    the existing empty-context exporter API.
+
 Version 1.15.1
 --------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(libedhoc VERSION 1.15.1 LANGUAGES C)
+project(libedhoc VERSION 1.16.0 LANGUAGES C)
 
 # The public headers use C11 anonymous unions, so the library is C11. (The old
 # `set_property(GLOBAL PROPERTY C_STANDARD 99)` was a no-op — C_STANDARD is a

--- a/doc/api/exporters.rst
+++ b/doc/api/exporters.rst
@@ -7,6 +7,13 @@ common consumer is :term:`OSCORE` — :c:func:`edhoc_export_oscore_session`
 returns the Master Secret, Master Salt and the two Sender/Recipient IDs
 required to bootstrap an OSCORE security context.
 
+Applications that derive non-OSCORE keying material can provide the full
+RFC 9528 exporter input through
+:c:func:`edhoc_export_prk_exporter_with_context`. The existing
+:c:func:`edhoc_export_prk_exporter` function is a compatibility shorthand for
+an empty exporter context. As required by RFC 9528, applications must use each
+``(label, context)`` pair for only one purpose.
+
 A key update (``KEY_UPDATE``) can be performed on an established context to
 re-derive ``PRK_out`` from fresh entropy without running a new handshake; the
 OSCORE export must then be re-run to obtain refreshed keys.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,7 +12,7 @@ from pathlib import Path
 project = "libedhoc"
 copyright = "2026, Kamil Kielbasa"
 author = "Kamil Kielbasa"
-version = "v1.15.1"
+version = "v1.16.0"
 release = version
 
 # -- General configuration ---------------------------------------------------

--- a/include/edhoc.h
+++ b/include/edhoc.h
@@ -541,8 +541,46 @@ int edhoc_message_error_process(const uint8_t *message_error,
  */
 
 /**
- * \brief Export derived keying material using the pseudorandom key exporter.
- * 
+ * \brief Export context-bound keying material using the pseudorandom key exporter.
+ *
+ * Implements EDHOC_Exporter(label, context, length) from RFC 9528, Section 4.2.1.
+ * The caller must use each (label, context) pair for only one purpose.
+ *
+ * \param[in,out] edhoc_context         EDHOC context.
+ * \param label                         PRK exporter label.
+ * \param[in] context                   Application-defined exporter context. May be NULL when
+ *                                      \p context_length is zero.
+ * \param context_length                Size of the \p context buffer in bytes.
+ * \param[out] secret                   Buffer where the generated secret is to be written.
+ * \param secret_length                 Size of the \p secret buffer in bytes.
+ *
+ * \retval #EDHOC_SUCCESS
+ *         Success.
+ * \retval #EDHOC_ERROR_INVALID_ARGUMENT
+ *         One or more input parameters are invalid.
+ * \retval #EDHOC_ERROR_BAD_STATE
+ *         Internal context state is incorrect.
+ * \retval #EDHOC_ERROR_NOT_PERMITTED
+ *         Operation not permitted in the current configuration.
+ * \retval #EDHOC_ERROR_CBOR_FAILURE
+ *         CBOR encoding failure.
+ * \retval #EDHOC_ERROR_CRYPTO_FAILURE
+ *         Cryptographic operation failure.
+ * \retval #EDHOC_ERROR_PSEUDORANDOM_KEY_FAILURE
+ *         Pseudorandom key derivation failed.
+ */
+int edhoc_export_prk_exporter_with_context(struct edhoc_context *edhoc_context,
+					   size_t label, const uint8_t *context,
+					   size_t context_length,
+					   uint8_t *secret,
+					   size_t secret_length);
+
+/**
+ * \brief Export derived keying material using an empty exporter context.
+ *
+ * This is equivalent to calling edhoc_export_prk_exporter_with_context() with
+ * an empty byte string as the exporter context.
+ *
  * \param[in,out] edhoc_context         EDHOC context.
  * \param label                         PRK exporter label.
  * \param[out] secret                   Buffer where the generated secret is to be written.

--- a/library/edhoc_exporter.c
+++ b/library/edhoc_exporter.c
@@ -311,11 +311,14 @@ STATIC int compute_prk_exporter(const struct edhoc_context *ctx,
  *      3. Compute pseudo random key exporter (PRK_exporter).
  *      4. Derive secret.
  */
-int edhoc_export_prk_exporter(struct edhoc_context *ctx, size_t label,
-			      uint8_t *secret, size_t secret_len)
+int edhoc_export_prk_exporter_with_context(struct edhoc_context *ctx,
+					   size_t label, const uint8_t *context,
+					   size_t context_len, uint8_t *secret,
+					   size_t secret_len)
 {
 	if (NULL == ctx || EDHOC_PRK_EXPORTER_PRIVATE_LABEL_MAXIMUM < label ||
-	    NULL == secret || 0 == secret_len) {
+	    (NULL == context && 0 != context_len) || NULL == secret ||
+	    0 == secret_len) {
 		EDHOC_LOG_ERR("Invalid arguments");
 		return EDHOC_ERROR_INVALID_ARGUMENT;
 	}
@@ -369,7 +372,7 @@ int edhoc_export_prk_exporter(struct edhoc_context *ctx, size_t label,
 	/* 4. Derive secret. */
 	size_t len = 0;
 	len += edhoc_cbor_int_mem_req((int32_t)label);
-	len += edhoc_cbor_bstr_oh(0); /* cbor empty byte string. */
+	len += context_len + edhoc_cbor_bstr_oh(context_len);
 	len += edhoc_cbor_int_mem_req((int32_t)csuite.hash_length);
 
 	EDHOC_MEM_ALLOC(uint8_t, info, len);
@@ -381,8 +384,8 @@ int edhoc_export_prk_exporter(struct edhoc_context *ctx, size_t label,
 
 	const struct info input_info = (struct info){
 		.info_label = (int32_t)label,
-		.info_context.value = NULL,
-		.info_context.len = 0,
+		.info_context.value = context,
+		.info_context.len = context_len,
 		.info_length = (uint32_t)secret_len,
 	};
 
@@ -424,6 +427,13 @@ int edhoc_export_prk_exporter(struct edhoc_context *ctx, size_t label,
 	EDHOC_LOG_HEXDUMP_DBG(secret, secret_len, "PRK exporter secret");
 
 	return EDHOC_SUCCESS;
+}
+
+int edhoc_export_prk_exporter(struct edhoc_context *ctx, size_t label,
+			      uint8_t *secret, size_t secret_len)
+{
+	return edhoc_export_prk_exporter_with_context(ctx, label, NULL, 0,
+						      secret, secret_len);
 }
 
 int edhoc_export_key_update(struct edhoc_context *ctx, const uint8_t *entropy,

--- a/tests/integration/test_rfc9529_chapter2.c
+++ b/tests/integration/test_rfc9529_chapter2.c
@@ -1378,6 +1378,18 @@ TEST(rfc9529_chapter2, prk_exporter)
 	TEST_ASSERT_EQUAL_UINT8_ARRAY(OSCORE_Master_Secret, master_secret,
 				      ARRAY_SIZE(OSCORE_Master_Secret));
 
+	uint8_t master_secret_with_context[ARRAY_SIZE(OSCORE_Master_Secret)] = {
+		0
+	};
+	ret = edhoc_export_prk_exporter_with_context(
+		init_ctx, OSCORE_EXTRACT_LABEL_MASTER_SECRET, NULL, 0,
+		master_secret_with_context,
+		ARRAY_SIZE(master_secret_with_context));
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(OSCORE_Master_Secret,
+				      master_secret_with_context,
+				      ARRAY_SIZE(master_secret_with_context));
+
 	uint8_t master_salt[ARRAY_SIZE(OSCORE_Master_Salt)] = { 0 };
 
 	/* EDHOC PRK exporter - OSCORE master salt. */
@@ -1407,6 +1419,54 @@ TEST(rfc9529_chapter2, prk_exporter)
 	ret = edhoc_export_prk_exporter(init_ctx, label, secret_3,
 					ARRAY_SIZE(secret_3));
 	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+}
+
+TEST(rfc9529_chapter2, prk_exporter_with_context)
+{
+	struct edhoc_context *contexts[] = { init_ctx, resp_ctx };
+	for (size_t i = 0; i < ARRAY_SIZE(contexts); ++i) {
+		contexts[i]->status = EDHOC_SM_COMPLETED;
+		contexts[i]->th_state = EDHOC_TH_STATE_4;
+		contexts[i]->th_len = ARRAY_SIZE(TH_4);
+		memcpy(contexts[i]->th, TH_4, ARRAY_SIZE(TH_4));
+		contexts[i]->prk_state = EDHOC_PRK_STATE_4E3M;
+		contexts[i]->prk_len = ARRAY_SIZE(PRK_4e3m);
+		memcpy(contexts[i]->prk, PRK_4e3m, ARRAY_SIZE(PRK_4e3m));
+	}
+
+	const uint8_t context[] = { 0x72, 0x73, 0x6d, 0x70 };
+	const uint8_t expected_secret[] = {
+		0x7c, 0x6b, 0xb2, 0xfa, 0x7b, 0x34, 0xb5, 0x71,
+		0x9a, 0x26, 0xf8, 0xc0, 0xdc, 0xf0, 0xf1, 0x27,
+		0x40, 0xcf, 0x6f, 0x8a, 0x15, 0x6f, 0x19, 0x2c,
+		0x05, 0xa1, 0x89, 0x76, 0x9c, 0x19, 0xb6, 0x88,
+	};
+	uint8_t init_secret[ARRAY_SIZE(expected_secret)] = { 0 };
+	uint8_t resp_secret[ARRAY_SIZE(expected_secret)] = { 0 };
+
+	ret = edhoc_export_prk_exporter_with_context(
+		init_ctx, EDHOC_PRK_EXPORTER_PRIVATE_LABEL_MINIMUM, context,
+		ARRAY_SIZE(context), init_secret, ARRAY_SIZE(init_secret));
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_secret, init_secret,
+				      ARRAY_SIZE(expected_secret));
+
+	ret = edhoc_export_prk_exporter_with_context(
+		resp_ctx, EDHOC_PRK_EXPORTER_PRIVATE_LABEL_MINIMUM, context,
+		ARRAY_SIZE(context), resp_secret, ARRAY_SIZE(resp_secret));
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_EQUAL_UINT8_ARRAY(init_secret, resp_secret,
+				      ARRAY_SIZE(init_secret));
+
+	const uint8_t other_context[] = { 0x52, 0x53, 0x4d, 0x50 };
+	uint8_t other_secret[ARRAY_SIZE(expected_secret)] = { 0 };
+	ret = edhoc_export_prk_exporter_with_context(
+		init_ctx, EDHOC_PRK_EXPORTER_PRIVATE_LABEL_MINIMUM,
+		other_context, ARRAY_SIZE(other_context), other_secret,
+		ARRAY_SIZE(other_secret));
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_NOT_EQUAL(0, memcmp(init_secret, other_secret,
+					ARRAY_SIZE(init_secret)));
 }
 
 TEST(rfc9529_chapter2, handshake_real_crypto)
@@ -2372,6 +2432,7 @@ TEST_GROUP_RUNNER(rfc9529_chapter2)
 	RUN_TEST_CASE(rfc9529_chapter2, message_4_process);
 	RUN_TEST_CASE(rfc9529_chapter2, handshake);
 	RUN_TEST_CASE(rfc9529_chapter2, prk_exporter);
+	RUN_TEST_CASE(rfc9529_chapter2, prk_exporter_with_context);
 	RUN_TEST_CASE(rfc9529_chapter2, handshake_real_crypto);
 	RUN_TEST_CASE(rfc9529_chapter2, handshake_real_crypto_ead_single);
 	RUN_TEST_CASE(rfc9529_chapter2, handshake_real_crypto_ead_many);

--- a/tests/unit/api/test_api_negative.c
+++ b/tests/unit/api/test_api_negative.c
@@ -541,6 +541,16 @@ TEST(api_negative, export_prk_exporter_null_ctx)
 	TEST_ASSERT_EQUAL(EDHOC_ERROR_INVALID_ARGUMENT, ret);
 }
 
+TEST(api_negative, export_prk_exporter_with_context_null_ctx)
+{
+	const uint8_t context[] = { 0x01 };
+	uint8_t secret[32];
+	int ret = edhoc_export_prk_exporter_with_context(
+		NULL, EDHOC_PRK_EXPORTER_PRIVATE_LABEL_MINIMUM, context,
+		ARRAY_SIZE(context), secret, sizeof(secret));
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_INVALID_ARGUMENT, ret);
+}
+
 TEST(api_negative, export_oscore_session_null_ctx)
 {
 	uint8_t ms[16], salt[8], sid[8], rid[8];
@@ -717,6 +727,7 @@ TEST_GROUP_RUNNER(api_negative)
 	RUN_TEST_CASE(api_negative, message_error_process_null_buf);
 
 	RUN_TEST_CASE(api_negative, export_prk_exporter_null_ctx);
+	RUN_TEST_CASE(api_negative, export_prk_exporter_with_context_null_ctx);
 	RUN_TEST_CASE(api_negative, export_oscore_session_null_ctx);
 	RUN_TEST_CASE(api_negative, export_oscore_session_null_ms);
 	RUN_TEST_CASE(api_negative, export_oscore_session_null_salt);

--- a/tests/unit/exporters/test_exporters.c
+++ b/tests/unit/exporters/test_exporters.c
@@ -257,6 +257,18 @@ TEST(exporters, prk_exporter_zero_length)
 	edhoc_context_deinit(&ctx);
 }
 
+TEST(exporters, prk_exporter_with_context_null_context)
+{
+	struct edhoc_context ctx = { 0 };
+	edhoc_context_init(&ctx);
+	uint8_t secret[32];
+	int ret = edhoc_export_prk_exporter_with_context(
+		&ctx, EDHOC_PRK_EXPORTER_PRIVATE_LABEL_MINIMUM, NULL, 1, secret,
+		sizeof(secret));
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_INVALID_ARGUMENT, ret);
+	edhoc_context_deinit(&ctx);
+}
+
 TEST(exporters, prk_exporter_invalid_label)
 {
 	struct edhoc_context ctx = { 0 };
@@ -376,6 +388,7 @@ TEST_GROUP_RUNNER(exporters)
 
 	RUN_TEST_CASE(exporters, prk_exporter_null_secret);
 	RUN_TEST_CASE(exporters, prk_exporter_zero_length);
+	RUN_TEST_CASE(exporters, prk_exporter_with_context_null_context);
 	RUN_TEST_CASE(exporters, prk_exporter_invalid_label);
 	RUN_TEST_CASE(exporters, prk_exporter_bad_state);
 	/* OSCORE CID CBOR encode failures */


### PR DESCRIPTION
Hi,
This PR adds a context-aware EDHOC exporter API.
I'm not a security expert, so please review. This PR was prepared with assistance from GPT-5.6 Sol Extra High.

```c
int edhoc_export_prk_exporter_with_context(
    struct edhoc_context *edhoc_context,
    size_t label,
    const uint8_t *context,
    size_t context_length,
    uint8_t *secret,
    size_t secret_length);
```

RFC 9528 Section 4.2.1 defines the exporter as:
```text
EDHOC_Exporter(exporter_label, context, length)
```

The existing edhoc_export_prk_exporter() API always encoded context as an empty byte string. The new function allows applications to supply the complete exporter context.
The existing function remains available and delegates to the new function with an empty context, preserving source compatibility and existing OSCORE output.

We are using libedhoc to add end-to-end encryption to RSMP, a traffic-management protocol used by constrained roadside equipment.
The RSMP security profile needs to bind application-specific information into the exported keying material, including the Secure RSMP profile, endpoint roles, and authenticated peer identities. RFC 9528 provides the exporter context
parameter for this kind of application-specific domain separation.
Without context support, applications must either use only an exporter label or add a separate key-derivation layer outside libedhoc. Exposing the standard context parameter lets applications use the complete RFC 9528 exporter interface directly.

Changes:
Add edhoc_export_prk_exporter_with_context().
Encode the supplied context as the bstr in the exporter info structure.
Reject a NULL context when context_length is non-zero.
Retain edhoc_export_prk_exporter() as an empty-context compatibility wrapper.
Document the RFC requirement that each (label, context) pair is used for only one purpose.
Update the API documentation and changelog.

Tests cover:
Compatibility between the existing API and an explicitly empty context.
A fixed known-answer vector for a non-empty context.
Identical output from initiator and responder using the same context.
Different output when the context changes.
Invalid context and null-context arguments.

Full test suite:
758 Tests
0 Failures
0 Ignored