### PR TITLE
fix(error): retain processed errors in context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+* Add context-aware error-message processing so cipher-suite negotiation
+  recovery can retrieve both local and peer suite lists through the error API.
+
 Version 2.0.1
 -------------
 

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -62,6 +62,21 @@ To send an EDHOC error message to the peer:
    edhoc_message_error_compose(buf, buf_size, &buf_len,
                                EDHOC_ERROR_CODE_UNSPECIFIED_ERROR, &info);
 
+To receive an error into the current session and retain its negotiation state:
+
+.. code-block:: c
+
+   int ret = edhoc_message_error_process_with_context(ctx, buf, buf_len, NULL);
+   if (ret == EDHOC_SUCCESS) {
+       enum edhoc_error_code err;
+       edhoc_error_get_code(ctx, &err);
+
+       if (err == EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE) {
+           edhoc_error_get_cipher_suites(ctx, own, own_size, &own_len,
+                                         peer, peer_size, &peer_len);
+       }
+   }
+
 API pages
 ---------
 

--- a/include/edhoc/edhoc.h
+++ b/include/edhoc/edhoc.h
@@ -461,8 +461,9 @@ int edhoc_message_error_compose(uint8_t *message_error,
  * \brief Process a received EDHOC error message.
  *
  *        Decodes a received error message into its error code and error
- *        information; receiving one indicates the peer aborted the session
- *        (RFC 9528: 6).
+ *        information without modifying an EDHOC context. Use
+ *        \ref edhoc_message_error_process_with_context to record a received
+ *        error in a session (RFC 9528: 6).
  *
  * \param[in] message_error             Buffer containing the message error.
  * \param message_error_length          Length of the \p message_error in bytes.
@@ -477,6 +478,32 @@ int edhoc_message_error_process(const uint8_t *message_error,
 				size_t message_error_length,
 				enum edhoc_error_code *error_code,
 				struct edhoc_error_info *error_info);
+
+/**
+ * \brief Process a received EDHOC error message into a session context.
+ *
+ *        Decodes the error, records its code in \p edhoc_context and aborts the
+ *        current session. For
+ *        #EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE, it also records the
+ *        peer's suites so \ref edhoc_error_get_cipher_suites returns both the
+ *        local and peer lists needed for recovery (RFC 9528: 6.3.1).
+ *
+ *        The optional \p error_info receives the decoded information just as
+ *        in \ref edhoc_message_error_process. The context is updated even when
+ *        \p error_info is NULL or has no output buffer.
+ *
+ * \param[in,out] edhoc_context         EDHOC session that received the error.
+ * \param[in] message_error             Buffer containing the message error.
+ * \param message_error_length          Length of the \p message_error in bytes.
+ * \param[out] error_info               Optional EDHOC error information.
+ *
+ * \retval #EDHOC_SUCCESS
+ *         Success.
+ * \return Negative error code on failure (\ref edhoc-error-codes).
+ */
+int edhoc_message_error_process_with_context(
+	struct edhoc_context *edhoc_context, const uint8_t *message_error,
+	size_t message_error_length, struct edhoc_error_info *error_info);
 
 /**@}*/
 

--- a/library/core/edhoc_message_error.c
+++ b/library/core/edhoc_message_error.c
@@ -14,12 +14,18 @@
 LOG_MODULE_DECLARE(libedhoc, CONFIG_LIBEDHOC_LOG_LEVEL);
 #endif
 
+/* Build-time configuration (Kconfig provides these on Zephyr): */
+#ifndef __ZEPHYR__
+#include <edhoc_config.h>
+#endif
+
 /* EDHOC public headers: */
 #include <edhoc/edhoc.h>
 #include <edhoc/types.h>
 #include <edhoc/values.h>
 
 /* EDHOC internal headers: */
+#include "edhoc_context_internal.h"
 #include "edhoc_macros_internal.h"
 #include "edhoc_backend_log.h"
 
@@ -156,27 +162,25 @@ int edhoc_message_error_compose(uint8_t *msg_err, size_t msg_err_size,
 	return EDHOC_SUCCESS;
 }
 
-int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
-				enum edhoc_error_code *code,
-				struct edhoc_error_info *info)
+static int decode_message_error(const uint8_t *msg_err, size_t msg_err_len,
+				struct message_error *result)
 {
-	if (NULL == msg_err || 0 == msg_err_len || NULL == code) {
-		EDHOC_LOG_ERR("Invalid arguments");
-		return EDHOC_ERROR_INVALID_ARGUMENT;
-	}
-
-	int ret = EDHOC_ERROR_GENERIC_ERROR;
-	struct message_error result = { 0 };
-
 	size_t len = 0;
-	ret = cbor_decode_message_error(msg_err, msg_err_len, &result, &len);
+	int ret = cbor_decode_message_error(msg_err, msg_err_len, result, &len);
 
 	if (ZCBOR_SUCCESS != ret) {
 		EDHOC_LOG_ERR("CBOR dec error msg: %d", ret);
 		return EDHOC_ERROR_CBOR_FAILURE;
 	}
 
-	switch (result.message_error_ERR_CODE) {
+	return EDHOC_SUCCESS;
+}
+
+static int process_decoded_message_error(const struct message_error *result,
+					 enum edhoc_error_code *code,
+					 struct edhoc_error_info *info)
+{
+	switch (result->message_error_ERR_CODE) {
 	case EDHOC_ERROR_CODE_SUCCESS: {
 		*code = EDHOC_ERROR_CODE_SUCCESS;
 		break;
@@ -185,14 +189,15 @@ int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
 	case EDHOC_ERROR_CODE_UNSPECIFIED_ERROR: {
 		*code = EDHOC_ERROR_CODE_UNSPECIFIED_ERROR;
 
-		if (false == result.message_error_ERR_INFO_present) {
+		if (false == result->message_error_ERR_INFO_present) {
 			break;
 		}
 
 		if (message_error_ERR_INFO_tstr_c !=
-		    result.message_error_ERR_INFO.message_error_ERR_INFO_choice) {
+		    result->message_error_ERR_INFO
+			    .message_error_ERR_INFO_choice) {
 			EDHOC_LOG_ERR("ERR_INFO does not match ERR_CODE: %d",
-				      result.message_error_ERR_INFO
+				      result->message_error_ERR_INFO
 					      .message_error_ERR_INFO_choice);
 			return EDHOC_ERROR_NOT_PERMITTED;
 		}
@@ -202,7 +207,7 @@ int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
 			break;
 
 		const struct zcbor_string *tstr =
-			&result.message_error_ERR_INFO
+			&result->message_error_ERR_INFO
 				 .message_error_ERR_INFO_tstr;
 
 		if (tstr->len > info->entries_size) {
@@ -221,14 +226,15 @@ int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
 	case EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE: {
 		*code = EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE;
 
-		if (false == result.message_error_ERR_INFO_present) {
+		if (false == result->message_error_ERR_INFO_present) {
 			break;
 		}
 
 		if (message_error_ERR_INFO_suites_m_c !=
-		    result.message_error_ERR_INFO.message_error_ERR_INFO_choice) {
+		    result->message_error_ERR_INFO
+			    .message_error_ERR_INFO_choice) {
 			EDHOC_LOG_ERR("ERR_INFO does not match ERR_CODE: %d",
-				      result.message_error_ERR_INFO
+				      result->message_error_ERR_INFO
 					      .message_error_ERR_INFO_choice);
 			return EDHOC_ERROR_NOT_PERMITTED;
 		}
@@ -238,7 +244,7 @@ int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
 			break;
 
 		const struct suites_r *suites =
-			&result.message_error_ERR_INFO
+			&result->message_error_ERR_INFO
 				 .message_error_ERR_INFO_suites_m;
 
 		switch (suites->suites_choice) {
@@ -281,9 +287,99 @@ int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
 
 	default:
 		EDHOC_LOG_ERR("Unknown error code in message: %d",
-			      result.message_error_ERR_CODE);
+			      result->message_error_ERR_CODE);
 		return EDHOC_ERROR_NOT_PERMITTED;
 	}
 
+	return EDHOC_SUCCESS;
+}
+
+int edhoc_message_error_process(const uint8_t *msg_err, size_t msg_err_len,
+				enum edhoc_error_code *code,
+				struct edhoc_error_info *info)
+{
+	if (NULL == msg_err || 0 == msg_err_len || NULL == code) {
+		EDHOC_LOG_ERR("Invalid arguments");
+		return EDHOC_ERROR_INVALID_ARGUMENT;
+	}
+
+	struct message_error result = { 0 };
+	int ret = decode_message_error(msg_err, msg_err_len, &result);
+
+	if (EDHOC_SUCCESS != ret)
+		return ret;
+
+	return process_decoded_message_error(&result, code, info);
+}
+
+int edhoc_message_error_process_with_context(struct edhoc_context *ctx,
+					     const uint8_t *msg_err,
+					     size_t msg_err_len,
+					     struct edhoc_error_info *info)
+{
+	if (NULL == ctx || NULL == msg_err || 0 == msg_err_len) {
+		EDHOC_LOG_ERR("Invalid arguments");
+		return EDHOC_ERROR_INVALID_ARGUMENT;
+	}
+
+	if (!ctx->is_init) {
+		EDHOC_LOG_ERR("Bad state");
+		return EDHOC_ERROR_BAD_STATE;
+	}
+
+	struct message_error result = { 0 };
+	int ret = decode_message_error(msg_err, msg_err_len, &result);
+
+	if (EDHOC_SUCCESS != ret)
+		return ret;
+
+	enum edhoc_error_code code = EDHOC_ERROR_CODE_SUCCESS;
+	int32_t peer_csuites[CONFIG_LIBEDHOC_MAX_NR_OF_CIPHER_SUITES] = { 0 };
+	struct edhoc_error_info peer_info = {
+		.cipher_suites = peer_csuites,
+		.entries_size = ARRAY_SIZE(peer_csuites),
+	};
+	struct edhoc_error_info *decoded_info = info;
+
+	if (EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE ==
+	    result.message_error_ERR_CODE)
+		decoded_info = &peer_info;
+
+	ret = process_decoded_message_error(&result, &code, decoded_info);
+
+	if (EDHOC_SUCCESS != ret)
+		return ret;
+
+	if (EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE == code) {
+		if (NULL != info && NULL != info->cipher_suites &&
+		    0 != info->entries_size) {
+			if (info->entries_size < peer_info.entries_length) {
+				EDHOC_LOG_ERR("Buffer too small: %zu, %zu",
+					      peer_info.entries_length,
+					      info->entries_size);
+				return EDHOC_ERROR_BUFFER_TOO_SMALL;
+			}
+
+			info->entries_length = peer_info.entries_length;
+			memcpy(info->cipher_suites, peer_info.cipher_suites,
+			       sizeof(*info->cipher_suites) *
+				       peer_info.entries_length);
+		}
+	}
+
+	memset(&ctx->negotiation.peer_cipher_suite, 0,
+	       sizeof(ctx->negotiation.peer_cipher_suite));
+
+	if (EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE == code) {
+		ctx->negotiation.peer_cipher_suite.count =
+			peer_info.entries_length;
+
+		for (size_t i = 0; i < peer_info.entries_length; ++i)
+			ctx->negotiation.peer_cipher_suite.entry[i].value =
+				peer_info.cipher_suites[i];
+	}
+
+	ctx->error_code = code;
+	ctx->state.machine = EDHOC_SM_ABORTED;
 	return EDHOC_SUCCESS;
 }

--- a/tests/linux/rfc9529/test_rfc9528_negotiation.c
+++ b/tests/linux/rfc9529/test_rfc9528_negotiation.c
@@ -247,21 +247,29 @@ TEST(rfc9528_negotiation, example_1)
 
 	/* 5a. Initiator process error message. */
 	enum edhoc_error_code error_code_init = -1;
-	int32_t cipher_suites_init[1] = { 0 };
-	struct edhoc_error_info error_info_init = {
-		.cipher_suites = cipher_suites_init,
-		.entries_size = ARRAY_SIZE(cipher_suites_init),
-		.entries_length = 0,
-	};
-	ret = edhoc_message_error_process(msg_err, msg_err_len,
-					  &error_code_init, &error_info_init);
+	ret = edhoc_message_error_process_with_context(&init_ctx, msg_err,
+						       msg_err_len, NULL);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	ret = edhoc_error_get_code(&init_ctx, &error_code_init);
 	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
 	TEST_ASSERT_EQUAL(EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE,
 			  error_code_init);
-	TEST_ASSERT_EQUAL(ARRAY_SIZE(csuites_resp),
-			  error_info_init.entries_length);
-	TEST_ASSERT_EQUAL(csuites_resp[0].value,
-			  error_info_init.cipher_suites[0]);
+	TEST_ASSERT_EQUAL(EDHOC_SM_ABORTED, init_ctx.state.machine);
+
+	size_t own_csuites_init_len = 0;
+	int32_t own_csuites_init[1] = { 0 };
+	size_t peer_csuites_init_len = 0;
+	int32_t peer_csuites_init[1] = { 0 };
+	ret = edhoc_error_get_cipher_suites(
+		&init_ctx, own_csuites_init, ARRAY_SIZE(own_csuites_init),
+		&own_csuites_init_len, peer_csuites_init,
+		ARRAY_SIZE(peer_csuites_init), &peer_csuites_init_len);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(ARRAY_SIZE(csuites_init), own_csuites_init_len);
+	TEST_ASSERT_EQUAL(csuites_init[0].value, own_csuites_init[0]);
+	TEST_ASSERT_EQUAL(ARRAY_SIZE(csuites_resp), peer_csuites_init_len);
+	TEST_ASSERT_EQUAL(csuites_resp[0].value, peer_csuites_init[0]);
 
 	/* 5b. Initiator reinitialize context with new cipher suites. */
 	ret = edhoc_context_init(&init_ctx);
@@ -490,8 +498,11 @@ TEST(rfc9528_negotiation, example_2)
 		.entries_length = 0,
 	};
 
-	ret = edhoc_message_error_process(msg_err, msg_err_len,
-					  &error_code_init, &error_info_init);
+	ret = edhoc_message_error_process_with_context(
+		&init_ctx, msg_err, msg_err_len, &error_info_init);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	ret = edhoc_error_get_code(&init_ctx, &error_code_init);
 	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
 	TEST_ASSERT_EQUAL(EDHOC_ERROR_CODE_WRONG_SELECTED_CIPHER_SUITE,
 			  error_code_init);
@@ -501,6 +512,23 @@ TEST(rfc9528_negotiation, example_2)
 			  error_info_init.cipher_suites[0]);
 	TEST_ASSERT_EQUAL(csuites_resp[1].value,
 			  error_info_init.cipher_suites[1]);
+	TEST_ASSERT_EQUAL(EDHOC_SM_ABORTED, init_ctx.state.machine);
+
+	size_t own_csuites_init_len = 0;
+	int32_t own_csuites_init[2] = { 0 };
+	size_t peer_csuites_init_len = 0;
+	int32_t peer_csuites_init[2] = { 0 };
+	ret = edhoc_error_get_cipher_suites(
+		&init_ctx, own_csuites_init, ARRAY_SIZE(own_csuites_init),
+		&own_csuites_init_len, peer_csuites_init,
+		ARRAY_SIZE(peer_csuites_init), &peer_csuites_init_len);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(ARRAY_SIZE(csuites_init), own_csuites_init_len);
+	TEST_ASSERT_EQUAL(csuites_init[0].value, own_csuites_init[0]);
+	TEST_ASSERT_EQUAL(csuites_init[1].value, own_csuites_init[1]);
+	TEST_ASSERT_EQUAL(ARRAY_SIZE(csuites_resp), peer_csuites_init_len);
+	TEST_ASSERT_EQUAL(csuites_resp[0].value, peer_csuites_init[0]);
+	TEST_ASSERT_EQUAL(csuites_resp[1].value, peer_csuites_init[1]);
 
 	/* 5b. Initiator reinitialize context with new cipher suites. */
 	ret = edhoc_context_init(&init_ctx);

--- a/tests/linux/unit/api/test_api_negative.c
+++ b/tests/linux/unit/api/test_api_negative.c
@@ -821,6 +821,35 @@ TEST(api_negative, message_error_process_null_buf)
 	TEST_ASSERT_EQUAL(EDHOC_ERROR_INVALID_ARGUMENT, ret);
 }
 
+TEST(api_negative, message_error_process_with_context_null_params)
+{
+	const uint8_t msg[] = { 0x00 };
+	struct edhoc_context ctx = { 0 };
+
+	int ret = edhoc_context_init(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	ret = edhoc_message_error_process_with_context(NULL, msg,
+						       ARRAY_SIZE(msg), NULL);
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_INVALID_ARGUMENT, ret);
+
+	ret = edhoc_message_error_process_with_context(&ctx, NULL, 0, NULL);
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_INVALID_ARGUMENT, ret);
+
+	ret = edhoc_context_deinit(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+}
+
+TEST(api_negative, message_error_process_with_context_not_initialized)
+{
+	const uint8_t msg[] = { 0x00 };
+	struct edhoc_context ctx = { 0 };
+
+	int ret = edhoc_message_error_process_with_context(
+		&ctx, msg, ARRAY_SIZE(msg), NULL);
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_BAD_STATE, ret);
+}
+
 TEST(api_negative, export_raw_null_ctx)
 {
 	uint8_t secret[32] = { 0 };
@@ -1047,6 +1076,10 @@ TEST_GROUP_RUNNER(api_negative)
 	RUN_TEST_CASE(api_negative, message_4_process_null_ctx);
 	RUN_TEST_CASE(api_negative, message_error_compose_null_buf);
 	RUN_TEST_CASE(api_negative, message_error_process_null_buf);
+	RUN_TEST_CASE(api_negative,
+		      message_error_process_with_context_null_params);
+	RUN_TEST_CASE(api_negative,
+		      message_error_process_with_context_not_initialized);
 
 	RUN_TEST_CASE(api_negative, export_raw_null_ctx);
 	RUN_TEST_CASE(api_negative, export_oscore_context_raw_null_ctx);

--- a/tests/linux/unit/coverage/test_coverage_error.c
+++ b/tests/linux/unit/coverage/test_coverage_error.c
@@ -104,6 +104,17 @@ TEST(coverage_error, error_msg_process_text_too_small)
 
 	ret = edhoc_message_error_process(buf, len, &code, &recv_info);
 	TEST_ASSERT_EQUAL(EDHOC_ERROR_BUFFER_TOO_SMALL, ret);
+
+	struct edhoc_context ctx = { 0 };
+	ret = edhoc_context_init(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	ret = edhoc_message_error_process_with_context(&ctx, buf, len,
+						       &recv_info);
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_BUFFER_TOO_SMALL, ret);
+
+	ret = edhoc_context_deinit(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
 }
 
 TEST(coverage_error, error_msg_process_suites_too_small)
@@ -132,6 +143,17 @@ TEST(coverage_error, error_msg_process_suites_too_small)
 
 	ret = edhoc_message_error_process(buf, len, &code, &recv_info);
 	TEST_ASSERT_EQUAL(EDHOC_ERROR_BUFFER_TOO_SMALL, ret);
+
+	struct edhoc_context ctx = { 0 };
+	ret = edhoc_context_init(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	ret = edhoc_message_error_process_with_context(&ctx, buf, len,
+						       &recv_info);
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_BUFFER_TOO_SMALL, ret);
+
+	ret = edhoc_context_deinit(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
 }
 
 TEST(coverage_error, error_msg_compose_suites_null_info)

--- a/tests/linux/unit/error/test_error_message.c
+++ b/tests/linux/unit/error/test_error_message.c
@@ -11,6 +11,7 @@
 
 /* EDHOC headers: */
 #include <edhoc/edhoc.h>
+#include "edhoc_context_internal.h"
 #include "edhoc_macros_internal.h"
 
 /* Standard library headers: */
@@ -200,6 +201,49 @@ TEST(error_message, unknown_credential_referenced)
 	TEST_ASSERT_EQUAL(error_code, recv_error_code);
 }
 
+TEST(error_message, unspecified_error_with_context)
+{
+	size_t buffer_len = 0;
+	uint8_t buffer[100] = { 0 };
+
+	const char text[] = "diagnostic";
+	const struct edhoc_error_info error_info = {
+		.text_string = (char *)text,
+		.entries_size = sizeof(text) - 1,
+		.entries_length = sizeof(text) - 1,
+	};
+	ret = edhoc_message_error_compose(buffer, ARRAY_SIZE(buffer),
+					  &buffer_len,
+					  EDHOC_ERROR_CODE_UNSPECIFIED_ERROR,
+					  &error_info);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	struct edhoc_context ctx = { 0 };
+	ret = edhoc_context_init(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	char received_text[100] = { 0 };
+	struct edhoc_error_info received_info = {
+		.text_string = received_text,
+		.entries_size = ARRAY_SIZE(received_text),
+	};
+	ret = edhoc_message_error_process_with_context(&ctx, buffer, buffer_len,
+						       &received_info);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+
+	enum edhoc_error_code code = EDHOC_ERROR_CODE_SUCCESS;
+	ret = edhoc_error_get_code(&ctx, &code);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+	TEST_ASSERT_EQUAL(EDHOC_ERROR_CODE_UNSPECIFIED_ERROR, code);
+	TEST_ASSERT_EQUAL(sizeof(text) - 1, received_info.entries_length);
+	TEST_ASSERT_EQUAL_STRING_LEN(text, received_text,
+				     received_info.entries_length);
+	TEST_ASSERT_EQUAL(EDHOC_SM_ABORTED, ctx.state.machine);
+
+	ret = edhoc_context_deinit(&ctx);
+	TEST_ASSERT_EQUAL(EDHOC_SUCCESS, ret);
+}
+
 TEST(error_message, compose_unknown_code)
 {
 	uint8_t buffer[100] = { 0 };
@@ -352,6 +396,7 @@ TEST_GROUP_RUNNER(error_message)
 	RUN_TEST_CASE(error_message, wrong_selected_cipher_suite_one);
 	RUN_TEST_CASE(error_message, wrong_selected_cipher_suite_many);
 	RUN_TEST_CASE(error_message, unknown_credential_referenced);
+	RUN_TEST_CASE(error_message, unspecified_error_with_context);
 	RUN_TEST_CASE(error_message, compose_unknown_code);
 	RUN_TEST_CASE(error_message, compose_cipher_suite_written_gt_total);
 	RUN_TEST_CASE(error_message, compose_tiny_buffer);


### PR DESCRIPTION
While working on the Ruby bindings GPT-5.6 Sol identified this. I also used it to prepare this fix.
All tests pass in our repo.

## Summary
Add `edhoc_message_error_process_with_context()` for processing a received EDHOC error message as part of a session.

The existing `edhoc_message_error_process()` remains available as a stateless decoder and retains its current behavior.

## Motivation
A received Wrong Selected Cipher Suite error contains the peer's supported cipher suites, but the existing processing function has no context argument. It therefore cannot update `ctx->error_code` or the peer cipher-suite list.

Consequently, `edhoc_error_get_cipher_suites()` cannot return the local and peer suite lists needed by the initiator recovery flow described in RFC 9528 Section 6.3.1.

## Changes
- Add `edhoc_message_error_process_with_context()`.
- Record the received protocol error code in the session context.
- Record peer cipher suites for Wrong Selected Cipher Suite errors.
- Transition the context to `EDHOC_SM_ABORTED` after successfully processing a peer error.
- Allow decoded error information to be returned through an optional output buffer.
- Preserve the existing stateless error-processing API.
- Update the API documentation and changelog.
- Update the RFC 9528 negotiation tests to exercise recovery through the context getters.
- Add negative, error-message, and coverage tests for the new API.

After processing a negotiation error, callers can use `edhoc_error_get_code()` and `edhoc_error_get_cipher_suites()` to retrieve the state retained by the context before reinitializing it for a retry.